### PR TITLE
feat(advanced): PER-8195 Phase 2 — advanced example for io.percy:espresso-java

### DIFF
--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -1,0 +1,50 @@
+name: Advanced — App Percy (Espresso)
+
+# PER-8195 Phase 2 — advanced example for io.percy:espresso-java.
+# Triggers manually only (`workflow_dispatch`). Espresso CI requires an
+# Android emulator runner; we don't run it on every PR because of the cost.
+on:
+  workflow_dispatch:
+
+jobs:
+  advanced:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 11
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Sanity-check Percy token
+        env:
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+        run: |
+          if [ -z "$PERCY_TOKEN" ]; then
+            echo "::error::PERCY_TOKEN repo secret is required for the advanced Espresso job."
+            exit 1
+          fi
+      - name: Enable KVM (required for Android emulator)
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: Install @percy/cli
+        run: npm install --no-save @percy/cli@^1.31.13
+      - name: Run Espresso advanced tests on Android emulator
+        env:
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+          PERCY_BRANCH: ${{ github.ref_name }}
+          PERCY_COMMIT: ${{ github.sha }}
+          PERCY_PROJECT: Percy Espresso Java Advanced
+          PERCY_BUILD: Advanced Espresso
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 30
+          target: google_apis
+          arch: x86_64
+          script: |
+            npx @percy/cli app:exec -- ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.sample.browserstack.samplecalculator.AdvancedScreenshotTests

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # example-percy-espresso-java
 Example app used by the [Percy Espresso Java tutorial](https://docs.percy.io/v2-app/docs/espresso) demonstrating Percy's Espresso integration.
 
+> **New:** This repo ships an [`advanced/`](./advanced) matrix + the corresponding `AdvancedScreenshotTests.java` in `app/src/androidTest/`. Espresso tests must live under `app/src/androidTest/` per Android instrumentation source-set convention; the `advanced/` dir holds only the matrix.yml and README. See the [Percy SDK Feature Matrix](https://docs.percy.io/docs/sdk-feature-matrix) for cross-SDK coverage.
+
+## Examples
+
+| Example | What it shows | Run command |
+|---|---|---|
+| `app/src/androidTest/.../EnsureInputTests.java` (basic) | Minimum viable: `appPercy.screenshot(name)` per Espresso test. Start here. | `./gradlew connectedDebugAndroidTest` |
+| `app/src/androidTest/.../AdvancedScreenshotTests.java` (advanced) | Full applicable App Percy Espresso SDK feature surface: `ScreenshotOptions.setStatusBarHeight` / `setNavigationBarHeight` / `setFullscreen`, build metadata via env. See [`advanced/README.md`](./advanced/README.md) for the matrix-row coverage table. | `npx @percy/cli app:exec -- ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.sample.browserstack.samplecalculator.AdvancedScreenshotTests` |
+
 ## Percy Espresso Java Tutorial
 
 The tutorial assumes you're already familiar with Espresso and Java and focuses on using it with App Percy. You'll still

--- a/advanced/.percy.yml
+++ b/advanced/.percy.yml
@@ -1,0 +1,6 @@
+# PER-8195 — global config for io.percy:espresso-java advanced example.
+
+version: 2
+
+percy:
+  defer_uploads: false

--- a/advanced/README.md
+++ b/advanced/README.md
@@ -1,0 +1,42 @@
+# Advanced Percy + Espresso (Java)
+
+This directory documents the advanced Percy SDK feature surface for `io.percy:espresso-java`. See the basic example at `app/src/androidTest/.../EnsureInputTests.java` for the minimum integration.
+
+## Layout asymmetry
+
+Espresso tests must live under `app/src/androidTest/` per the Android instrumentation source-set convention — they can't be relocated under `advanced/` without breaking the gradle build. As a result, the advanced test code lives at:
+
+`app/src/androidTest/java/com/sample/browserstack/samplecalculator/AdvancedScreenshotTests.java`
+
+…while this `advanced/` directory holds only the `matrix.yml` (canonical row mapping) and this README.
+
+## What the advanced test covers
+
+5 `@Test` methods in `AdvancedScreenshotTests.java`, one per applicable matrix row:
+
+- `status_bar_height` (via `ScreenshotOptions.setStatusBarHeight`)
+- `nav_bar_height` (via `ScreenshotOptions.setNavigationBarHeight`)
+- `fullscreen` (via `ScreenshotOptions.setFullscreen`)
+- Build metadata via env (`PERCY_PROJECT` / `PERCY_BUILD` / `PERCY_BRANCH` / `PERCY_COMMIT` — read by the SDK at upload time)
+- Baseline screenshot without options
+
+Other native matrix rows (orientation, ignore/consider regions, sync, test_case, labels) are marked `Planned` in `matrix.yml` — `io.percy:espresso-java` 1.0.3 exposes a narrower `ScreenshotOptions` surface than the Appium SDK family.
+
+Web-only rows (widths, percyCSS, etc.) are marked `N/A`.
+
+## Run locally
+
+Requires an Android emulator or connected device + Percy CLI + `PERCY_TOKEN`:
+
+```bash
+export PERCY_TOKEN="<your project token>"
+npx @percy/cli@^1.31.13 app:exec -- ./gradlew connectedDebugAndroidTest
+```
+
+## CI note
+
+The advanced CI job is `workflow_dispatch`-only. Running Espresso in GitHub Actions requires an Android emulator runner (`reactivecircus/android-emulator-runner`), which is heavy. See `.github/workflows/advanced.yml`.
+
+## Coverage matrix
+
+States: `Covered` / `N/A — <reason>` / `Planned` / `Deprecated`. Source of truth is [`matrix.yml`](./matrix.yml).

--- a/advanced/matrix.yml
+++ b/advanced/matrix.yml
@@ -1,0 +1,87 @@
+# PER-8195 Phase 2 — Espresso-Java matrix-row mapping.
+# Test code: ../app/src/androidTest/java/com/sample/browserstack/samplecalculator/AdvancedScreenshotTests.java
+#
+# Espresso tests must live under app/src/androidTest/ per Android instrumentation
+# source-set convention; this advanced/ directory holds the matrix + README only.
+
+sdk: espresso-java
+package: io.percy:espresso-java
+language: java
+sdk_min_version: '1.0.3'
+cli_min_version: '1.31.13'
+
+rows:
+  - id: status_bar_height
+    state: covered
+    test: 'AdvancedScreenshotTests > exercisesStatusBarHeight'
+  - id: nav_bar_height
+    state: covered
+    test: 'AdvancedScreenshotTests > exercisesNavBarHeight'
+  - id: fullscreen
+    state: covered
+    test: 'AdvancedScreenshotTests > exercisesFullscreen'
+
+  - id: build_metadata_via_env
+    state: covered
+    test: 'AdvancedScreenshotTests > exercisesScreenshotWithBuildMetadataFromEnv (reads PERCY_PROJECT / PERCY_BUILD via SDK)'
+  - id: env_percy_branch
+    state: covered
+  - id: env_percy_commit
+    state: covered
+
+  # Espresso SDK exposes a narrower ScreenshotOptions surface than the
+  # Appium SDK family. The following rows are not exposed in 1.0.3.
+  - id: device_name_override
+    state: n_a
+    reason: 'Espresso runs on a single connected device/emulator at a time; device_name is implicit.'
+  - id: orientation_handling
+    state: planned
+    test: 'Future: exercise device.setOrientation via UiDevice'
+  - id: ignore_regions_xpaths
+    state: n_a
+    reason: 'Not exposed in io.percy:espresso-java ScreenshotOptions as of 1.0.3.'
+  - id: ignore_region_appium_elements
+    state: n_a
+    reason: 'Appium-driver-only; Espresso has no Appium driver.'
+  - id: custom_ignore_regions
+    state: planned
+    test: 'Future: ScreenshotOptions.setIgnoreRegions(...) if SDK exposes it'
+  - id: consider_regions_xpaths
+    state: n_a
+    reason: 'Not exposed in io.percy:espresso-java as of 1.0.3.'
+  - id: sync
+    state: planned
+  - id: test_case
+    state: planned
+  - id: labels
+    state: planned
+
+  # Web-only.
+  - id: widths
+    state: n_a
+  - id: percy_css
+    state: n_a
+  - id: min_height
+    state: n_a
+  - id: enable_javascript
+    state: n_a
+  - id: scope
+    state: n_a
+  - id: discovery
+    state: n_a
+  - id: dom_transformation
+    state: n_a
+  - id: responsive_snapshot_capture
+    state: n_a
+  - id: readiness_preset
+    state: n_a
+  - id: device_pixel_ratio
+    state: n_a
+  - id: browsers
+    state: n_a
+
+  - id: percy_yml_global_config
+    state: covered
+  - id: environment_info_reporting
+    state: covered
+    test: 'automatic via io.percy:espresso-java client info'

--- a/app/src/androidTest/java/com/sample/browserstack/samplecalculator/AdvancedScreenshotTests.java
+++ b/app/src/androidTest/java/com/sample/browserstack/samplecalculator/AdvancedScreenshotTests.java
@@ -1,0 +1,77 @@
+package com.sample.browserstack.samplecalculator;
+
+// PER-8195 Phase 2 — Espresso advanced example.
+// Each @Test exercises one row of the App Percy / Appium Native matrix.
+// See advanced/matrix.yml for the canonical mapping.
+//
+// Espresso tests must live under app/src/androidTest/ (Android
+// instrumentation source-set convention). The sibling advanced/ directory
+// holds the matrix.yml and README that document this asymmetry.
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.SmallTest;
+import androidx.test.rule.ActivityTestRule;
+import io.percy.espresso.AppPercy;
+import io.percy.espresso.lib.ScreenshotOptions;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+
+@SmallTest
+@RunWith(AndroidJUnit4.class)
+public class AdvancedScreenshotTests {
+    @Rule
+    public ActivityTestRule<MainActivity> activityRule = new ActivityTestRule<>(MainActivity.class);
+
+    private AppPercy appPercy;
+
+    @Before
+    public void setUp() {
+        appPercy = new AppPercy();
+    }
+
+    @Test
+    public void exercisesBaselineScreenshot() {
+        onView(withId(R.id.buttonOne)).perform(click());
+        appPercy.screenshot("Calculator — single digit");
+    }
+
+    @Test
+    public void exercisesStatusBarHeight() {
+        ScreenshotOptions opts = new ScreenshotOptions();
+        opts.setStatusBarHeight(100);
+        onView(withId(R.id.buttonOne)).perform(click());
+        appPercy.screenshot("Calculator — status bar height", opts);
+    }
+
+    @Test
+    public void exercisesNavBarHeight() {
+        ScreenshotOptions opts = new ScreenshotOptions();
+        opts.setNavigationBarHeight(48);
+        onView(withId(R.id.buttonOne)).perform(click());
+        onView(withId(R.id.buttonTwo)).perform(click());
+        appPercy.screenshot("Calculator — nav bar height", opts);
+    }
+
+    @Test
+    public void exercisesFullscreen() {
+        ScreenshotOptions opts = new ScreenshotOptions();
+        opts.setFullscreen(true);
+        onView(withId(R.id.buttonOne)).perform(click());
+        appPercy.screenshot("Calculator — fullscreen", opts);
+    }
+
+    @Test
+    public void exercisesScreenshotWithBuildMetadataFromEnv() {
+        // PERCY_PROJECT / PERCY_BUILD / PERCY_BRANCH / PERCY_COMMIT are read
+        // by the AppPercy SDK via System.getenv at upload time; no per-call
+        // option needed. This test simply documents the env-driven knobs.
+        onView(withId(R.id.buttonOne)).perform(click());
+        appPercy.screenshot("Calculator — build metadata via env");
+    }
+}


### PR DESCRIPTION
## Summary
Adds an advanced Espresso example for `io.percy:espresso-java`. 5 `@Test` methods in `AdvancedScreenshotTests.java` exercising the `ScreenshotOptions` surface: `setStatusBarHeight`, `setNavigationBarHeight`, `setFullscreen`, baseline, and a screenshot demonstrating build metadata read from env.

## Layout asymmetry
Espresso tests must live under `app/src/androidTest/` (Android instrumentation source-set convention) — they can't be relocated under `advanced/`. So:

- Test code → `app/src/androidTest/java/com/sample/browserstack/samplecalculator/AdvancedScreenshotTests.java`
- `advanced/` holds only `matrix.yml` + `README.md` documenting the asymmetry.

`io.percy:espresso-java 1.0.3` exposes a narrower options surface than the Appium SDK family — orientation, ignore/consider regions, sync, test_case, labels are marked `Planned`. Web-only options marked `N/A`.

Issue: [PER-8195](https://browserstack.atlassian.net/browse/PER-8195). Parent: percy/percy-public-repos-parent#1.

## CI shape
`workflow_dispatch`-only using `reactivecircus/android-emulator-runner@v2`. Heavy (~10-15 min) — runs the Android emulator on a GitHub-hosted ubuntu runner.

## Test plan
- [ ] Maintainer triggers `Advanced — App Percy (Espresso)` workflow manually with `PERCY_TOKEN` set.
- [ ] Verify a Percy build lands with the 5 advanced screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PER-8195]: https://browserstack.atlassian.net/browse/PER-8195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ