### PR TITLE
fix: correct ScreenshotOptions method names in advanced Espresso test

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Example app used by the [Percy Espresso Java tutorial](https://docs.percy.io/v2-
 | Example | What it shows | Run command |
 |---|---|---|
 | `app/src/androidTest/.../EnsureInputTests.java` (basic) | Minimum viable: `appPercy.screenshot(name)` per Espresso test. Start here. | `./gradlew connectedDebugAndroidTest` |
-| `app/src/androidTest/.../AdvancedScreenshotTests.java` (advanced) | Full applicable App Percy Espresso SDK feature surface: `ScreenshotOptions.setStatusBarHeight` / `setNavigationBarHeight` / `setFullscreen`, build metadata via env. See [`advanced/README.md`](./advanced/README.md) for the matrix-row coverage table. | `npx @percy/cli app:exec -- ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.sample.browserstack.samplecalculator.AdvancedScreenshotTests` |
+| `app/src/androidTest/.../AdvancedScreenshotTests.java` (advanced) | Full applicable App Percy Espresso SDK feature surface: `ScreenshotOptions.setStatusBarHeight` / `setNavBarHeight` / `setFullScreen`, build metadata via env. See [`advanced/README.md`](./advanced/README.md) for the matrix-row coverage table. | `npx @percy/cli app:exec -- ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.sample.browserstack.samplecalculator.AdvancedScreenshotTests` |
 
 ## Percy Espresso Java Tutorial
 

--- a/advanced/README.md
+++ b/advanced/README.md
@@ -15,8 +15,8 @@ Espresso tests must live under `app/src/androidTest/` per the Android instrument
 5 `@Test` methods in `AdvancedScreenshotTests.java`, one per applicable matrix row:
 
 - `status_bar_height` (via `ScreenshotOptions.setStatusBarHeight`)
-- `nav_bar_height` (via `ScreenshotOptions.setNavigationBarHeight`)
-- `fullscreen` (via `ScreenshotOptions.setFullscreen`)
+- `nav_bar_height` (via `ScreenshotOptions.setNavBarHeight`)
+- `fullscreen` (via `ScreenshotOptions.setFullScreen`)
 - Build metadata via env (`PERCY_PROJECT` / `PERCY_BUILD` / `PERCY_BRANCH` / `PERCY_COMMIT` — read by the SDK at upload time)
 - Baseline screenshot without options
 

--- a/app/src/androidTest/java/com/sample/browserstack/samplecalculator/AdvancedScreenshotTests.java
+++ b/app/src/androidTest/java/com/sample/browserstack/samplecalculator/AdvancedScreenshotTests.java
@@ -52,7 +52,7 @@ public class AdvancedScreenshotTests {
     @Test
     public void exercisesNavBarHeight() {
         ScreenshotOptions opts = new ScreenshotOptions();
-        opts.setNavigationBarHeight(48);
+        opts.setNavBarHeight(48);
         onView(withId(R.id.buttonOne)).perform(click());
         onView(withId(R.id.buttonTwo)).perform(click());
         appPercy.screenshot("Calculator — nav bar height", opts);
@@ -61,7 +61,7 @@ public class AdvancedScreenshotTests {
     @Test
     public void exercisesFullscreen() {
         ScreenshotOptions opts = new ScreenshotOptions();
-        opts.setFullscreen(true);
+        opts.setFullScreen(true);
         onView(withId(R.id.buttonOne)).perform(click());
         appPercy.screenshot("Calculator — fullscreen", opts);
     }


### PR DESCRIPTION
## Problem

`AdvancedScreenshotTests.java` doesn't compile against the published `io.percy:espresso-java` SDK:

```
AdvancedScreenshotTests.java:55: error: cannot find symbol  method setNavigationBarHeight(int)
AdvancedScreenshotTests.java:64: error: cannot find symbol  method setFullscreen(boolean)
```

`ScreenshotOptions` exposes **`setNavBarHeight(Integer)`** and **`setFullScreen(Boolean)`** — not `setNavigationBarHeight` / `setFullscreen`. This breaks the `advanced.yml` CI job, which builds these instrumentation tests.

Verified the wrong names fail to compile against **both 1.0.3** (the pinned version) **and 1.0.5-beta.0**, so this is a long-standing bug in the example, independent of any SDK version.

## Fix

- `AdvancedScreenshotTests.java`: `setNavigationBarHeight(48)` → `setNavBarHeight(48)`; `setFullscreen(true)` → `setFullScreen(true)`
- `README.md` + `advanced/README.md`: update the matching API references

Confirmed `:app:assembleDebugAndroidTest` now compiles + packages cleanly against the SDK.

## Out of scope (separate, pre-existing)

The repo's dependency repositories are `google()` + `jcenter()`; **jcenter is sunset**, so `io.percy` won't resolve from it on a clean machine — `mavenCentral()` should be added. Flagging here; happy to do a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)